### PR TITLE
Supporting both Sail Ids when reading generator input.

### DIFF
--- a/generator.htm
+++ b/generator.htm
@@ -13,12 +13,12 @@
 	<meta name="author" lang="fr" content="toxcct">
 	<meta name="copyright" content="Toxcct 2018">
 	<link rel="icon" type="image/png" href="favicon-gen.png" />
-	<link rel="stylesheet"	type="text/css"	href="css/general.css?v=2.3.4"		media="screen" />
-	<link rel="stylesheet"	type="text/css"	href="css/generator.css?v=2.3.4"	media="screen" />
+	<link rel="stylesheet"	type="text/css"	href="css/general.css?v=2.3.5"		media="screen" />
+	<link rel="stylesheet"	type="text/css"	href="css/generator.css?v=2.3.5"	media="screen" />
 	<script type="text/javascript" src="js/lib/jquery-3.2.1.min.js"				defer ></script>
-	<script type="text/javascript" src="js/polars_reader.js?v=2.3.4"			defer ></script>
-	<script type="text/javascript" src="js/generator.js?v=2.3.4"				defer ></script>
-	<script type="text/javascript" src="js/lib/gtag.js?v=2.3.4"					defer ></script>
+	<script type="text/javascript" src="js/polars_reader.js?v=2.3.5"			defer ></script>
+	<script type="text/javascript" src="js/generator.js?v=2.3.5"				defer ></script>
+	<script type="text/javascript" src="js/lib/gtag.js?v=2.3.5"					defer ></script>
 </head>
 <body>
 	<article>

--- a/js/generator.js
+++ b/js/generator.js
@@ -17,7 +17,7 @@ $(function() {
 //=================================//
 
 var Generator = (function(){
-	var _version		= "2.3.4";
+	var _version		= "2.3.5";
 	var _bInitialized	= false;
 	var _bError			= false;
 	var _bShowAsArray	= true;

--- a/js/polars_reader.js
+++ b/js/polars_reader.js
@@ -5,12 +5,19 @@
 var PolarsReader = (function() {
 	var _sailsNames	= {
 		"Jib"		: { "en":"Jib",					"fr":"Foc",					"es":"Foque"					},
+		"JIB"		: { "en":"Jib",					"fr":"Foc",					"es":"Foque"					},
 		"Spi"		: { "en":"Spi",					"fr":"Spi",					"es":"Spi"						},
+		"SPI"		: { "en":"Spi",					"fr":"Spi",					"es":"Spi"						},
 		"Staysail"	: { "en":"Staysail",			"fr":"Trinquette",			"es":"Trinquetilla"				},
+		"STAYSAIL"	: { "en":"Staysail",			"fr":"Trinquette",			"es":"Trinquetilla"				},
 		"LightJib"	: { "en":"Light jib",			"fr":"Génois léger",		"es":"Foque ligero"				},
+		"LIGHT_JIB"	: { "en":"Light jib",			"fr":"Génois léger",		"es":"Foque ligero"				},
 		"Code0"		: { "en":"Code 0",				"fr":"Code 0",				"es":"Código 0"					},
+		"CODE_0"	: { "en":"Code 0",				"fr":"Code 0",				"es":"Código 0"					},
 		"HeavyGnk"	: { "en":"Heavy Gennaker",		"fr":"Spi lourd",			"es":"Gennaker pesado"			},
-		"LightGnk"	: { "en":"Light Gennaker",		"fr":"Spi léger",			"es":"Gennaker ligero"			}
+		"HEAVY_GNK"	: { "en":"Heavy Gennaker",		"fr":"Spi lourd",			"es":"Gennaker pesado"			},
+		"LightGnk"	: { "en":"Light Gennaker",		"fr":"Spi léger",			"es":"Gennaker ligero"			},
+		"LIGHT_GNK"	: { "en":"Light Gennaker",		"fr":"Spi léger",			"es":"Gennaker ligero"			}
 	};
 	var _optionsNames = {
 		"light"		: { "en":"Light wind sails",	"fr":"Voiles petit temps",	"es":"Velas para viento suave"	},

--- a/release_notes.htm
+++ b/release_notes.htm
@@ -129,6 +129,7 @@
 				<h5>2.3</h5>
 				<ul>
 					<li><b>Feature:</b> Added XML format support for MaxSea TimeZero router</li>
+					<li><b>Feature:</b> Added support for both Sail Id spellings</li>
 					<li><b>Update:</b> Renamed the radio button with their relative router</li>
 					<li><b>BugFix:</b> Prevent the 'Copy to Clipboard' button from being clickable during processing</li>
 				</ul>


### PR DESCRIPTION
This is mainly because VR seem to use both Ids depending on the polars
they provide.
However, this fix concerns the generator only, because the chart app
relies on locally stored json files; their format don't change in time.