### PR TITLE
Patch 1

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -54,7 +54,7 @@ footer a {color:#8c8cb8; text-decoration:underline;}
 
 
 /**** CONTENT *******/
-article							{width:800px; cursor:default;}
+article							{width:850px; cursor:default;}
 article.grid2cols				{display:grid; grid-template-columns:1fr 600px; grid-gap:7px;}
 article.grid3cols				{display:grid; grid-template-columns:1fr 425px 1fr; grid-gap:7px;}
 
@@ -65,7 +65,7 @@ article .sidebox.grid1cols				{display:grid; grid-gap:2px; grid-template-columns
 article .sidebox.grid2cols				{display:grid; grid-gap:2px 10px;grid-template-columns:60px 1fr;		}
 article .sidebox.grid2cols.c20x1fr		{display:grid; grid-gap:2px; grid-template-columns:20px 1fr;			}
 article .sidebox.grid3cols				{display:grid; grid-gap:2px; grid-template-columns:20px 1fr 20px;		}
-article .sidebox.grid3cols.c20x1frx35	{display:grid; grid-gap:2px; grid-template-columns:20px 1fr 35px;		}
+article .sidebox.grid3cols.c20x1frx85	{display:grid; grid-gap:2px; grid-template-columns:20px 1fr 85px;		}
 article .sidebox.grid5cols				{display:grid; grid-gap:2px; grid-template-columns:1fr 1fr 1fr 1fr 1fr;	}
 article .sidebox			> .title	{color:#999; width:95%; margin:0 auto 1px; padding-bottom:3px; border-bottom:1px solid #bbb; position:relative;}
 article .sidebox.grid1cols	> .title	{grid-column:span 1;}
@@ -75,7 +75,7 @@ article .sidebox.grid5cols	> .title	{grid-column:span 5;}
 article .sidebox.grid1cols	> .sep		{grid-column:span 1;}
 article .sidebox.grid2cols	> .sep		{grid-column:span 2;}
 article .sidebox.grid5cols	> .sep		{grid-column:span 5;}
-article .sidebox.grid5cols	> input		{grid-column:span 3; text-align:center; vertical-align:middle; height:18px; border:1px solid #999; padding:0;}
+article .sidebox.grid5cols	> input		{grid-column:span 2; text-align:center; vertical-align:middle; height:18px; border:1px solid #999; padding:0;}
 article .sidebox.grid5cols	> button	{width:35px; height:20px;}
 article .sidebox.grid1cols	> .column1	{text-align:center;	}
 article .sidebox.grid2cols	> .column1	{text-align:right;	}

--- a/css/general.css
+++ b/css/general.css
@@ -76,7 +76,7 @@ article .sidebox.grid5cols	> .title	{grid-column:span 5;}
 article .sidebox.grid1cols	> .sep		{grid-column:span 1;}
 article .sidebox.grid2cols	> .sep		{grid-column:span 2;}
 article .sidebox.grid5cols	> .sep		{grid-column:span 5;}
-article .sidebox.grid5cols	> input		{grid-column:span 2; text-align:center; vertical-align:middle; height:18px; border:1px solid #999; padding:0;}
+article .sidebox.grid5cols	> input		{grid-column:span 3; text-align:center; vertical-align:middle; height:18px; border:1px solid #999; padding:0; width:calc(100% - 2px);}
 article .sidebox.grid5cols	> button	{width:35px; height:20px;}
 article .sidebox.grid1cols	> .column1	{text-align:center;	}
 article .sidebox.grid2cols	> .column1	{text-align:right;	}

--- a/css/general.css
+++ b/css/general.css
@@ -65,6 +65,7 @@ article .sidebox.grid1cols				{display:grid; grid-gap:2px; grid-template-columns
 article .sidebox.grid2cols				{display:grid; grid-gap:2px 10px;grid-template-columns:60px 1fr;		}
 article .sidebox.grid2cols.c20x1fr		{display:grid; grid-gap:2px; grid-template-columns:20px 1fr;			}
 article .sidebox.grid3cols				{display:grid; grid-gap:2px; grid-template-columns:20px 1fr 20px;		}
+article .sidebox.grid3cols.c20x1frx35	{display:grid; grid-gap:2px; grid-template-columns:20px 1fr 35px;		}
 article .sidebox.grid3cols.c20x1frx85	{display:grid; grid-gap:2px; grid-template-columns:20px 1fr 85px;		}
 article .sidebox.grid5cols				{display:grid; grid-gap:2px; grid-template-columns:1fr 1fr 1fr 1fr 1fr;	}
 article .sidebox			> .title	{color:#999; width:95%; margin:0 auto 1px; padding-bottom:3px; border-bottom:1px solid #bbb; position:relative;}

--- a/index.htm
+++ b/index.htm
@@ -170,7 +170,7 @@
 				<input type="checkbox" class="column1" id="opt_hull"	/><label class="column2" for="opt_hull" >-</label><span></span>
 			</div>
 			<div class="sidebox grid3cols c20x1frx85">
-				<span class="title">Sails   - Speed (boost)
+				<span class="title">Sails   - Speed (Boost)
 					<input type="checkbox" id="opt_plotfullcurves" class="leftbtns" title="Plot full sails curves" />
 				</span>
 				<span class="column1 sail img Jib"		><input type="checkbox" class="leftbtns" /></span><span class="column2">-</span><span class="column3 val">0</span>

--- a/index.htm
+++ b/index.htm
@@ -141,7 +141,6 @@
 				<label class="input_lbl" title="True Wind Speed" for ="data_tws">TWS:</label>
 				<input type="text" id="data_tws" maxlength="5" class="val unit_kts center" value="0" autofocus />
 				<span class="input_lbl unit_kts"></span>
-				<span>&nbsp;</span>
 
 				<button id="btn_setsp_m10" title="-1 kt">&lt;&lt;</button>
 				<button id="btn_setsp_m1"  title="-0.1 kts">&lt;</button>

--- a/index.htm
+++ b/index.htm
@@ -141,6 +141,7 @@
 				<label class="input_lbl" title="True Wind Speed" for ="data_tws">TWS:</label>
 				<input type="text" id="data_tws" maxlength="5" class="val unit_kts center" value="0" autofocus />
 				<span class="input_lbl unit_kts"></span>
+				<span>&nbsp;</span>
 
 				<button id="btn_setsp_m10" title="-1 kt">&lt;&lt;</button>
 				<button id="btn_setsp_m1"  title="-0.1 kts">&lt;</button>
@@ -169,8 +170,8 @@
 					<input type="checkbox" id="foils_overlay" title="Display foils activation range" />
 				<input type="checkbox" class="column1" id="opt_hull"	/><label class="column2" for="opt_hull" >-</label><span></span>
 			</div>
-			<div class="sidebox grid3cols c20x1frx35">
-				<span class="title">Sails
+			<div class="sidebox grid3cols c20x1frx85">
+				<span class="title">Sails   - Speed (boost)
 					<input type="checkbox" id="opt_plotfullcurves" class="leftbtns" title="Plot full sails curves" />
 				</span>
 				<span class="column1 sail img Jib"		><input type="checkbox" class="leftbtns" /></span><span class="column2">-</span><span class="column3 val">0</span>

--- a/js/polars_app.js
+++ b/js/polars_app.js
@@ -48,6 +48,7 @@ var PolarsApp = (function(){
 		}
 	};
 	var _acceptedURLParams	= ["race_id", "twa", "tws", "light", "reach", "heavy", "foil", "hull", "utm_source"];
+	const sailTolerance = 1.014 ;  //  "autoSailChangeTolerance" in polar json, the same for all boats.
 
 
 	//Static Data retrieved from Server
@@ -1090,13 +1091,13 @@ var PolarsApp = (function(){
 			$("#data_twa_down"		 ).text(_twa_down			);
 			$("#data_vmg_down"		 ).text(_vmg_down			);
 
-			$(".sail.Jib"		).next().next().text(data.sailsSpeeds.Jib		.fix(2, true));
-			$(".sail.LightJib"	).next().next().text(data.sailsSpeeds.LightJib	.fix(2, true));
-			$(".sail.Staysail"	).next().next().text(data.sailsSpeeds.Staysail	.fix(2, true));
-			$(".sail.Code0"		).next().next().text(data.sailsSpeeds.Code0		.fix(2, true));
-			$(".sail.Spi"		).next().next().text(data.sailsSpeeds.Spi		.fix(2, true));
-			$(".sail.LightGnk"	).next().next().text(data.sailsSpeeds.LightGnk	.fix(2, true));
-			$(".sail.HeavyGnk"	).next().next().text(data.sailsSpeeds.HeavyGnk	.fix(2, true));
+			$(".sail.Jib"		).next().next().text(data.sailsSpeeds.Jib		.fix(3, true) + ( (					  (data.sailsSpeeds.Jib      * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.Jib      !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
+			$(".sail.LightJib"	).next().next().text(data.sailsSpeeds.LightJib	.fix(3, true) + ( ( _chk_opt_light && (data.sailsSpeeds.LightJib * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.LightJib !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
+			$(".sail.Staysail"	).next().next().text(data.sailsSpeeds.Staysail	.fix(3, true) + ( ( _chk_opt_heavy && (data.sailsSpeeds.Staysail * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.Staysail !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
+			$(".sail.Code0"		).next().next().text(data.sailsSpeeds.Code0		.fix(3, true) + ( ( _chk_opt_reach && (data.sailsSpeeds.Code0	 * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.Code0    !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
+			$(".sail.Spi"		).next().next().text(data.sailsSpeeds.Spi		.fix(3, true) + ( (					  (data.sailsSpeeds.Spi	 	 * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.Spi	     !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
+			$(".sail.LightGnk"	).next().next().text(data.sailsSpeeds.LightGnk	.fix(3, true) + ( ( _chk_opt_light && (data.sailsSpeeds.LightGnk * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.LightGnk !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
+			$(".sail.HeavyGnk"	).next().next().text(data.sailsSpeeds.HeavyGnk	.fix(3, true) + ( ( _chk_opt_heavy && (data.sailsSpeeds.HeavyGnk * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.HeavyGnk !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
 
 			$(".sail").removeClass("selected");
 			if (data.current.bestSail)

--- a/js/polars_app.js
+++ b/js/polars_app.js
@@ -48,8 +48,6 @@ var PolarsApp = (function(){
 		}
 	};
 	var _acceptedURLParams	= ["race_id", "twa", "tws", "light", "reach", "heavy", "foil", "hull", "utm_source"];
-	const sailTolerance = 1.014 ;  //  "autoSailChangeTolerance" in polar json, the same for all boats.
-
 
 	//Static Data retrieved from Server
 	var _races				= {};
@@ -1076,6 +1074,7 @@ var PolarsApp = (function(){
 			_vmg_up				= data.bestVMG.upwind.vmg;
 			_twa_down			= data.bestVMG.downwind.twa;
 			_vmg_down			= data.bestVMG.downwind.vmg;
+			_autoSailChangeTolerance = data.autoSailChangeTolerance;
 
 
 			$("#data_twa .val"		 ).text(_current_twa		);
@@ -1091,14 +1090,21 @@ var PolarsApp = (function(){
 			$("#data_twa_down"		 ).text(_twa_down			);
 			$("#data_vmg_down"		 ).text(_vmg_down			);
 
-			$(".sail.Jib"		).next().next().text(data.sailsSpeeds.Jib		.fix(3, true) + ( (					  (data.sailsSpeeds.Jib      * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.Jib      !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
-			$(".sail.LightJib"	).next().next().text(data.sailsSpeeds.LightJib	.fix(3, true) + ( ( _chk_opt_light && (data.sailsSpeeds.LightJib * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.LightJib !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
-			$(".sail.Staysail"	).next().next().text(data.sailsSpeeds.Staysail	.fix(3, true) + ( ( _chk_opt_heavy && (data.sailsSpeeds.Staysail * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.Staysail !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
-			$(".sail.Code0"		).next().next().text(data.sailsSpeeds.Code0		.fix(3, true) + ( ( _chk_opt_reach && (data.sailsSpeeds.Code0	 * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.Code0    !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
-			$(".sail.Spi"		).next().next().text(data.sailsSpeeds.Spi		.fix(3, true) + ( (					  (data.sailsSpeeds.Spi	 	 * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.Spi	     !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
-			$(".sail.LightGnk"	).next().next().text(data.sailsSpeeds.LightGnk	.fix(3, true) + ( ( _chk_opt_light && (data.sailsSpeeds.LightGnk * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.LightGnk !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
-			$(".sail.HeavyGnk"	).next().next().text(data.sailsSpeeds.HeavyGnk	.fix(3, true) + ( ( _chk_opt_heavy && (data.sailsSpeeds.HeavyGnk * sailTolerance > _current_boatspeed) && (data.sailsSpeeds.HeavyGnk !=_current_boatspeed)) ? (' (' +_current_boatspeed.fix(3, true) + ')' ) : "")  )  ;
-
+			for (var sail in data.sailsSpeeds) {
+				$(".sail." + sail ).next().next().text(data.sailsSpeeds[sail]	.fix(3, true));
+				if  (  (   ( ( (sail == "LightJib") || (sail == "LightGnk")) && _chk_opt_light ) 
+					    || ( ( (sail == "Staysail") || (sail == "HeavyGnk")) && _chk_opt_heavy )
+						|| (   (sail == "Code0")                             && _chk_opt_reach )
+						||     (sail == "Jib") 
+						||     (sail == "Spi") )
+					  && ( (data.sailsSpeeds[sail] * _autoSailChangeTolerance) > _current_boatspeed) 
+					  && ( sail != data.current.bestSail ) 
+					) {
+					$(".sail." + sail ).next().next().append(' <b>(B)<b>');
+					$(".sail." + sail ).next().next().attr("title", "En voile automatique, boost coef " + ((_current_boatspeed /data.sailsSpeeds[sail]).fix(4, true)) + " (peut profiter de la vitesse de la meilleure voile)" ) ;
+				}
+			}	
+			
 			$(".sail").removeClass("selected");
 			if (data.current.bestSail)
 				$(".sail." + data.current.bestSail).addClass("selected");

--- a/js/polars_chart.js
+++ b/js/polars_chart.js
@@ -88,7 +88,8 @@ var PolarsChart = (function(){
 					__boatType	: "",
 					__options	: []
 				},
-				sailsSpeeds : null
+				sailsSpeeds : null,
+				autoSailChangeTolerance : 0,
 			};
 			_maxFoilFactor = 1;
 
@@ -116,6 +117,8 @@ var PolarsChart = (function(){
 					_maxFoilFactor = _polarsData[i].best.foilFactor;
 				}
 			}
+			_currentResultset.autoSailChangeTolerance =  _polarsData[0].autoSailChangeTolerance;
+
 		}
 		else {
 			_currentResultset.current = {
@@ -646,7 +649,8 @@ var PolarsChart = (function(){
 	//		},
 	//		sailsSpeeds	: [
 	//			<String#SailId> : <Number>
-	//		]
+	//		],
+	//		autoSailChangeTolerance : <Number>
 	//	}
 	//---------------------------------
 

--- a/js/polars_reader.js
+++ b/js/polars_reader.js
@@ -68,7 +68,8 @@ var PolarsReader = (function() {
 
 		return {
 			best		: theoreticalSpeed(twa, tws, options),
-			all			: allSailsSpeeds(twa, tws, options)
+			all			: allSailsSpeeds(twa, tws, options),
+			autoSailChangeTolerance : _polars.autoSailChangeTolerance
 		};
 	}
 	function getFoilRange() {
@@ -264,7 +265,8 @@ var PolarsReader = (function() {
 	//		},
 	//		all	: [
 	//			<String#SailId> : <Number>
-	//		]
+	//		],
+	//		autoSailChangeTolerance : <Number>
 	//	}
 	//
 	// * PolarsReader.getFoilRange()


### PR DESCRIPTION
Ajout entre parenthèses de la vitesse réelle avec la tolérance de recouvrement des voiles (si on est en voile automatique, le changement de voile ne se fait pas si la vitesse de la meilleure voile est inférieur à la vitesse de la voile actuelle * 1.014. De plus, le bateau profite de la vitesse de la meilleure voile.)
J'ai dû élargie un peu les colonnes de chaque coté du graph pour faire tenir cette info.
et dans polars_app.js, ajout d'une constante "sailTolérance", le plus propre serait de prendre la valeur "autoSailChangeTolerance" dans le fichier json des polaires de chaque bateau. Mais j'ai fait au plus simple, car elle est identique pour tous les bateaux et n'a pas changé depuis 2 ans.